### PR TITLE
Enhance research with open access filter and PDF viewer

### DIFF
--- a/client/src/components/ResearchTab.jsx
+++ b/client/src/components/ResearchTab.jsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { TextField, Button, Box, CircularProgress, List, ListItem, ListItemText, Typography } from '@mui/material';
+import { TextField, Button, Box, CircularProgress, List, ListItem, ListItemText, Typography, Checkbox, FormControlLabel } from '@mui/material';
 
 export default function ResearchTab() {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [openAccessOnly, setOpenAccessOnly] = useState(false);
 
   const handleSearch = async () => {
     if (!query) return;
@@ -13,7 +14,7 @@ export default function ResearchTab() {
       const res = await fetch('/api/research/search', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ query })
+        body: JSON.stringify({ query, options: { openAccessOnly } })
       });
       const data = await res.json();
       setResults(data.papers || []);
@@ -34,24 +35,43 @@ export default function ResearchTab() {
           onChange={(e) => setQuery(e.target.value)}
           onKeyPress={(e) => e.key === 'Enter' && handleSearch()}
         />
+        <FormControlLabel
+          control={<Checkbox checked={openAccessOnly} onChange={(e) => setOpenAccessOnly(e.target.checked)} />}
+          label="Open Access"
+        />
         <Button variant="contained" onClick={handleSearch}>Search</Button>
       </Box>
       {loading && <CircularProgress />}
       {!loading && results.length > 0 && (
         <List>
-          {results.map((paper, idx) => (
-            <ListItem key={idx} alignItems="flex-start">
-              <ListItemText
-                primary={paper.title}
-                secondary={<>
-                  <Typography component="span" variant="body2" color="text.secondary">
-                    {paper.authors?.join(', ')} ({paper.year})
-                  </Typography>
-                  <br />{paper.venue}
-                </>}
-              />
-            </ListItem>
-          ))}
+            {results.map((paper, idx) => (
+              <ListItem key={idx} alignItems="flex-start" sx={{ flexDirection: 'column', alignItems: 'flex-start' }}>
+                <ListItemText
+                  primary={paper.title}
+                  secondary={
+                    <>
+                      <Typography component="span" variant="body2" color="text.secondary">
+                        {paper.authors?.join(', ')} ({paper.year})
+                      </Typography>
+                      <br />{paper.venue}
+                    </>
+                  }
+                />
+                <Box sx={{ mt: 1 }}>
+                  {paper.openAccessPdf ? (
+                    <Button size="small" variant="outlined" href={`/api/research/fetch-pdf?url=${encodeURIComponent(paper.openAccessPdf)}`} target="_blank">
+                      Read PDF
+                    </Button>
+                  ) : (
+                    paper.url && (
+                      <Button size="small" variant="outlined" href={paper.url} target="_blank">
+                        View Source
+                      </Button>
+                    )
+                  )}
+                </Box>
+              </ListItem>
+            ))}
         </List>
       )}
     </Box>

--- a/sermon-research-app/README.md
+++ b/sermon-research-app/README.md
@@ -69,6 +69,7 @@ npm start
 2. Enter your search terms in the General Search field
 3. Review results from multiple academic databases
 4. Select papers to add to your citation library
+5. Use the **Open Access** toggle to show only freely available papers
 
 ### Biblical Terms Search
 1. Use the Biblical Terms Search for theological concepts
@@ -100,6 +101,7 @@ npm start
 - `POST /api/research/scripture-search` - Scripture reference search
 - `GET /api/research/semantic-scholar/:query` - Direct Semantic Scholar search
 - `GET /api/research/crossref/:query` - Direct CrossRef search
+- `GET /api/research/fetch-pdf?url=` - Proxy to retrieve open access PDFs
 
 ### Sermon Routes
 - `POST /api/sermons` - Create new sermon

--- a/sermon-research-app/src/routes/research.js
+++ b/sermon-research-app/src/routes/research.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const axios = require('axios');
 const AcademicSearchService = require('../services/academicSearch');
 
 const router = express.Router();
@@ -97,6 +98,23 @@ router.get('/crossref/:query', async (req, res) => {
   } catch (error) {
     console.error('CrossRef route error:', error);
     res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// Fetch PDF through server to avoid CORS issues
+router.get('/fetch-pdf', async (req, res) => {
+  const { url } = req.query;
+  if (!url) {
+    return res.status(400).json({ error: 'PDF url is required' });
+  }
+
+  try {
+    const response = await axios.get(url, { responseType: 'arraybuffer' });
+    res.set('Content-Type', 'application/pdf');
+    res.send(response.data);
+  } catch (error) {
+    console.error('PDF fetch error:', error.message);
+    res.status(500).json({ error: 'Failed to fetch PDF' });
   }
 });
 

--- a/sermon-research-app/src/services/academicSearch.js
+++ b/sermon-research-app/src/services/academicSearch.js
@@ -108,7 +108,8 @@ class AcademicSearchService {
         venue: paper.venue,
         source: 'Semantic Scholar',
         doi: paper.externalIds?.DOI || null,
-        openAccess: paper.openAccessPdf !== null || paper.isOpenAccess
+        openAccess: paper.openAccessPdf !== null || paper.isOpenAccess,
+        openAccessPdf: paper.openAccessPdf?.url || null
       })),
       source: 'semantic-scholar',
       total: data.total


### PR DESCRIPTION
## Summary
- add open access PDF information in Semantic Scholar results
- support `/api/research/fetch-pdf` route to proxy PDFs
- allow open access-only searching from UI
- show `Read PDF` button for open papers
- document new API route and option in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run lint` in server *(fails: ESLint couldn't find a configuration file)*
- `npm test` in server *(fails: No tests found)*
- `npm test` in client *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686c20bfcae48325a64d644b67eedfc3